### PR TITLE
Ignore non-fatal Unicode exception

### DIFF
--- a/camerahub_tagger/main.py
+++ b/camerahub_tagger/main.py
@@ -92,9 +92,7 @@ def main():
         try:
             existing = img.read_exif()
         except UnicodeDecodeError as err:
-            cprint(f"{err} when reading {file}", "red")
-            failed.append(file)
-            continue
+            pass
 
         img.close()
 


### PR DESCRIPTION
Ignore Unicode exception as it is non-fatal, and only results in some tags not being populated

Fixes #34 